### PR TITLE
fix: Sign in failing with a missing csrf cookie on a fresh page load.

### DIFF
--- a/apps/web/src/lib/authula-client-browser.ts
+++ b/apps/web/src/lib/authula-client-browser.ts
@@ -10,10 +10,14 @@ import {
 import { COOKIE_CONSTANTS, HEADER_CONSTANTS } from "@repo/data-commons";
 
 import { envClient } from "@/constants/env-client";
+import { CSRFBootstrapPlugin } from "./csrf-bootstrap-plugin";
 
 export const authulaBrowserClient = createClient({
 	url: envClient.authulaUrl,
 	plugins: [
+		// Has to stay ahead of CSRFPlugin so the cookie exists by the time it
+		// looks for one.
+		new CSRFBootstrapPlugin(),
 		new CSRFPlugin({
 			cookieName: COOKIE_CONSTANTS.csrf.name,
 			headerName: HEADER_CONSTANTS.csrfToken,

--- a/apps/web/src/lib/csrf-bootstrap-plugin.test.ts
+++ b/apps/web/src/lib/csrf-bootstrap-plugin.test.ts
@@ -1,0 +1,119 @@
+import type { AuthulaClient, BeforeFetchHook, FetchContext } from "authula";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { CSRFBootstrapPlugin } from "./csrf-bootstrap-plugin";
+
+vi.mock("@repo/data-commons", () => ({
+	COOKIE_CONSTANTS: { csrf: { name: "authula_csrf_token" } },
+}));
+
+const AUTHULA_URL = "http://api.test/api/v1/auth";
+
+function setup(cookies: Record<string, string> = {}) {
+	const hooks: Array<BeforeFetchHook> = [];
+
+	const client = {
+		config: { url: AUTHULA_URL },
+		registerBeforeFetch: (hook: BeforeFetchHook) => {
+			hooks.push(hook);
+		},
+		getCookie: async (name: string) => cookies[name],
+	} as unknown as AuthulaClient;
+
+	new CSRFBootstrapPlugin().init(client);
+
+	return { beforeFetch: hooks[0] };
+}
+
+function request(method: string): FetchContext {
+	return {
+		url: `${AUTHULA_URL}/email-password/sign-in`,
+		init: { method },
+		meta: {},
+	};
+}
+
+function deferredResponse() {
+	let resolve!: () => void;
+	const settled = new Promise<void>((r) => {
+		resolve = r;
+	});
+	const fetchMock = vi.fn(() => settled.then(() => new Response(null)));
+	vi.stubGlobal("fetch", fetchMock);
+	return { fetchMock, resolve };
+}
+
+describe("CSRFBootstrapPlugin", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	test("should leave safe requests alone", async () => {
+		const { fetchMock } = deferredResponse();
+		const { beforeFetch } = setup();
+
+		await beforeFetch(request("GET"));
+		await beforeFetch(request("HEAD"));
+		await beforeFetch(request("OPTIONS"));
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test("should fetch the cookie before an unsafe request without one", async () => {
+		const { fetchMock, resolve } = deferredResponse();
+		const { beforeFetch } = setup();
+
+		const pending = beforeFetch(request("POST"));
+		resolve();
+		await pending;
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(`${AUTHULA_URL}/me`, {
+			method: "GET",
+			credentials: "include",
+		});
+	});
+
+	test("should skip the fetch when the cookie is already there", async () => {
+		const { fetchMock } = deferredResponse();
+		const { beforeFetch } = setup({ authula_csrf_token: "token" });
+
+		await beforeFetch(request("POST"));
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test("should share one fetch between concurrent unsafe requests", async () => {
+		const { fetchMock, resolve } = deferredResponse();
+		const { beforeFetch } = setup();
+
+		const pending = Promise.all([
+			beforeFetch(request("POST")),
+			beforeFetch(request("PATCH")),
+		]);
+		resolve();
+		await pending;
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("should fetch again once the previous attempt has finished", async () => {
+		const { fetchMock, resolve } = deferredResponse();
+		const { beforeFetch } = setup();
+
+		const first = beforeFetch(request("POST"));
+		resolve();
+		await first;
+		await beforeFetch(request("POST"));
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("should not swallow the request when the fetch fails", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+		const { beforeFetch } = setup();
+
+		await expect(beforeFetch(request("POST"))).resolves.toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/csrf-bootstrap-plugin.ts
+++ b/apps/web/src/lib/csrf-bootstrap-plugin.ts
@@ -1,0 +1,57 @@
+import type { AuthulaClient, Plugin } from "authula";
+
+import { COOKIE_CONSTANTS } from "@repo/data-commons";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * The API mints `authula_csrf_token` as a side effect of a safe request, so the
+ * browser only holds one once it has called the API itself. On a hard load of
+ * an auth page every call is made during SSR, which leaves the browser without
+ * the cookie and every CSRF protected POST — sign in, sign up, password reset —
+ * failing with a 403 `missing csrf cookie`.
+ *
+ * Make one safe call first so the cookie is there when `CSRFPlugin` reads it.
+ * This has to be registered before `CSRFPlugin`, hooks run in the order they
+ * were registered.
+ */
+export class CSRFBootstrapPlugin implements Plugin {
+	readonly id = "csrf-bootstrap";
+
+	private priming: Promise<void> | null = null;
+
+	init(client: AuthulaClient) {
+		client.registerBeforeFetch(async (ctx) => {
+			const method = (ctx.init.method ?? "GET").toUpperCase();
+			if (SAFE_METHODS.has(method)) {
+				return;
+			}
+
+			if (await client.getCookie(COOKIE_CONSTANTS.csrf.name)) {
+				return;
+			}
+
+			await this.prime(client.config.url);
+		});
+
+		return {};
+	}
+
+	private prime(url: string): Promise<void> {
+		if (!this.priming) {
+			this.priming = fetch(`${url.replace(/\/+$/, "")}/me`, {
+				method: "GET",
+				credentials: "include",
+			})
+				.then(() => undefined)
+				// Whatever went wrong here will go wrong again for the request that
+				// triggered this, and that one can report it with context.
+				.catch(() => undefined)
+				.finally(() => {
+					this.priming = null;
+				});
+		}
+
+		return this.priming;
+	}
+}


### PR DESCRIPTION
Signing in from a freshly loaded auth page fails with `403 missing csrf cookie`.

The API only sets `authula_csrf_token` on a response the browser receives, but on a hard load the `/auth` session check runs during SSR, so the browser never calls the API itself. The sign-in POST is its first request and has no cookie to send. It works right after you've been using the app because the dashboard's client-side calls leave one behind, and since that cookie has a 24 hour max age this only surfaces once it lapses. Sign up, password reset and sign out hit the same thing.

Fix is a small plugin that makes one GET to `/me` when the cookie is missing on an unsafe request, registered ahead of `CSRFPlugin` so the cookie exists by the time it looks. Concurrent requests share the fetch.

Checked on a self-hosted stack — cleared the cookie, hard loaded `/auth/sign-in`, signed in fine. Tests included.
