### PR TITLE
fix: Relay the Authula CSRF cookie through the SSR path.

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -2,6 +2,10 @@
 API_URL=""
 # e.g. http://localhost:8080/api/auth
 AUTHULA_URL=""
+# Only needed when the web app and the API are served from different hostnames
+# (e.g. app.example.com and api.example.com). Scopes the CSRF cookie to their
+# shared parent domain, e.g. ".example.com". Leave unset for local development.
+AUTH_COOKIE_DOMAIN=""
 
 # e.g. id of the extension, e.g. acbdefghijklmnopqrstuvwxyz
 VITE_EXTENSION_ID=""

--- a/apps/web/src/constants/env-server.ts
+++ b/apps/web/src/constants/env-server.ts
@@ -5,6 +5,7 @@ export const validatedEnv = createEnv({
 	server: {
 		AUTHULA_URL: z.string().nonempty(),
 		API_URL: z.string().nonempty(),
+		AUTH_COOKIE_DOMAIN: z.string().optional(),
 	},
 	runtimeEnv: process.env,
 	emptyStringAsUndefined: true,
@@ -13,4 +14,5 @@ export const validatedEnv = createEnv({
 export const envServer = {
 	authulaUrl: validatedEnv.AUTHULA_URL,
 	apiUrl: validatedEnv.API_URL,
+	authCookieDomain: validatedEnv.AUTH_COOKIE_DOMAIN,
 } as const;

--- a/apps/web/src/lib/authula-client-server.ts
+++ b/apps/web/src/lib/authula-client-server.ts
@@ -1,4 +1,3 @@
-import { getStartContext } from "@tanstack/start-storage-context";
 import { createClient } from "authula";
 import {
 	AdminPlugin,
@@ -11,39 +10,11 @@ import {
 import { COOKIE_CONSTANTS, HEADER_CONSTANTS } from "@repo/data-commons";
 
 import { envServer } from "@/constants/env-server";
+import { createSsrCookieStore } from "./ssr-cookie-store";
 
 export const authulaServerClient = createClient({
 	url: envServer.authulaUrl,
-	cookies: () => {
-		try {
-			const ctx = getStartContext({ throwIfNotFound: false });
-			if (!ctx) {
-				return {
-					getAll: () => [],
-					set: () => {},
-				};
-			}
-
-			const cookieHeader = ctx.request.headers.get("Cookie") || "";
-			const cookies = cookieHeader
-				.split(";")
-				.map((c) => {
-					const [name, value] = c.trim().split("=");
-					return { name, value: decodeURIComponent(value || "") };
-				})
-				.filter((c) => c.name);
-
-			return {
-				getAll: () => cookies,
-				set: () => {},
-			};
-		} catch {
-			return {
-				getAll: () => [],
-				set: () => {},
-			};
-		}
-	},
+	cookies: createSsrCookieStore,
 	plugins: [
 		new CSRFPlugin({
 			cookieName: COOKIE_CONSTANTS.csrf.name,

--- a/apps/web/src/lib/ssr-cookie-store.test.ts
+++ b/apps/web/src/lib/ssr-cookie-store.test.ts
@@ -1,0 +1,260 @@
+import {
+	getCookies,
+	getRequestProtocol,
+	getResponse,
+	setCookie,
+} from "@tanstack/react-start/server";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createSsrCookieStore } from "./ssr-cookie-store";
+
+vi.mock("@tanstack/react-start/server", () => ({
+	getCookies: vi.fn(),
+	getRequestProtocol: vi.fn(),
+	getResponse: vi.fn(),
+	setCookie: vi.fn(),
+}));
+
+vi.mock("@repo/data-commons", () => ({
+	COOKIE_CONSTANTS: { csrf: { name: "authula_csrf_token" } },
+}));
+
+const { envServerMock } = vi.hoisted(() => ({
+	envServerMock: { authCookieDomain: undefined as string | undefined },
+}));
+
+vi.mock("@/constants/env-server", () => ({
+	envServer: envServerMock,
+}));
+
+const stageResponseCookies = (setCookieHeaders: string[]): void => {
+	vi.mocked(getResponse).mockReturnValue({
+		headers: { getSetCookie: () => setCookieHeaders },
+	} as unknown as ReturnType<typeof getResponse>);
+};
+
+const CSRF_COOKIE = "authula_csrf_token";
+const SESSION_COOKIE = "authula.session_token";
+
+describe("SsrCookieStore", () => {
+	beforeEach(() => {
+		vi.mocked(getCookies).mockReturnValue({});
+		vi.mocked(getRequestProtocol).mockReturnValue("http");
+		stageResponseCookies([]);
+		envServerMock.authCookieDomain = undefined;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("getAll", () => {
+		test("should return the request cookies as name/value pairs", () => {
+			// Arrange
+			vi.mocked(getCookies).mockReturnValue({
+				[CSRF_COOKIE]: "token-1",
+				[SESSION_COOKIE]: "session-1",
+			});
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert
+			expect(cookies).toEqual([
+				{ name: CSRF_COOKIE, value: "token-1" },
+				{ name: SESSION_COOKIE, value: "session-1" },
+			]);
+		});
+
+		test("should preserve values containing an equals sign", () => {
+			// Arrange
+			vi.mocked(getCookies).mockReturnValue({
+				[SESSION_COOKIE]: "YWJjZGVm==",
+			});
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert
+			expect(cookies).toEqual([{ name: SESSION_COOKIE, value: "YWJjZGVm==" }]);
+		});
+
+		test("should include a csrf cookie already staged on the response", () => {
+			// Arrange — an earlier Authula call in this same render already relayed one
+			vi.mocked(getCookies).mockReturnValue({ [SESSION_COOKIE]: "session-1" });
+			stageResponseCookies([
+				`${CSRF_COOKIE}=staged-token; Path=/; Max-Age=86400; SameSite=Lax`,
+			]);
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert
+			expect(cookies).toContainEqual({
+				name: CSRF_COOKIE,
+				value: "staged-token",
+			});
+		});
+
+		test("should prefer the staged csrf cookie over the one the browser sent", () => {
+			// Arrange
+			vi.mocked(getCookies).mockReturnValue({ [CSRF_COOKIE]: "stale-token" });
+			stageResponseCookies([`${CSRF_COOKIE}=fresh-token; Path=/`]);
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert — one entry only, and it is the newer value
+			expect(cookies).toEqual([{ name: CSRF_COOKIE, value: "fresh-token" }]);
+		});
+
+		test("should ignore staged cookies outside the allowlist", () => {
+			// Arrange
+			stageResponseCookies([`${SESSION_COOKIE}=leaked; Path=/`]);
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert
+			expect(cookies).toEqual([]);
+		});
+
+		test("should return an empty list when there is no request context", () => {
+			// Arrange
+			vi.mocked(getCookies).mockImplementation(() => {
+				throw new Error("No request context");
+			});
+
+			// Act
+			const cookies = createSsrCookieStore().getAll();
+
+			// Assert
+			expect(cookies).toEqual([]);
+		});
+	});
+
+	describe("set", () => {
+		test("should relay the csrf cookie to the response", () => {
+			// Arrange
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1", {
+				path: "/",
+				maxAge: 86400,
+				sameSite: "lax",
+				httpOnly: false,
+			});
+
+			// Assert
+			expect(setCookie).toHaveBeenCalledWith(
+				CSRF_COOKIE,
+				"token-1",
+				expect.objectContaining({
+					path: "/",
+					maxAge: 86400,
+					sameSite: "lax",
+					httpOnly: false,
+				}),
+			);
+		});
+
+		test("should not relay cookies outside the allowlist", () => {
+			// Arrange
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(SESSION_COOKIE, "session-1", { path: "/", httpOnly: true });
+
+			// Assert
+			expect(setCookie).not.toHaveBeenCalled();
+		});
+
+		test("should discard the upstream domain when none is configured", () => {
+			// Arrange
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1", { domain: "api" });
+
+			// Assert
+			expect(setCookie).toHaveBeenCalledWith(
+				CSRF_COOKIE,
+				"token-1",
+				expect.objectContaining({ domain: undefined }),
+			);
+		});
+
+		test("should stamp the configured domain in place of the upstream one", () => {
+			// Arrange
+			envServerMock.authCookieDomain = ".example.com";
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1", { domain: "api" });
+
+			// Assert
+			expect(setCookie).toHaveBeenCalledWith(
+				CSRF_COOKIE,
+				"token-1",
+				expect.objectContaining({ domain: ".example.com" }),
+			);
+		});
+
+		test("should mark the cookie secure over https regardless of the upstream flag", () => {
+			// Arrange
+			vi.mocked(getRequestProtocol).mockReturnValue("https");
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1", { secure: false });
+
+			// Assert
+			expect(setCookie).toHaveBeenCalledWith(
+				CSRF_COOKIE,
+				"token-1",
+				expect.objectContaining({ secure: true }),
+			);
+		});
+
+		test("should not mark the cookie secure over http", () => {
+			// Arrange
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1", { secure: true });
+
+			// Assert
+			expect(setCookie).toHaveBeenCalledWith(
+				CSRF_COOKIE,
+				"token-1",
+				expect.objectContaining({ secure: false }),
+			);
+		});
+
+		test("should swallow errors when the response is no longer writable", () => {
+			// Arrange
+			vi.mocked(setCookie).mockImplementation(() => {
+				throw new Error("Headers already sent");
+			});
+			const store = createSsrCookieStore();
+
+			// Act & Assert
+			expect(() => store.set(CSRF_COOKIE, "token-1")).not.toThrow();
+		});
+
+		test("should be a no-op when there is no request context", () => {
+			// Arrange
+			vi.mocked(getCookies).mockImplementation(() => {
+				throw new Error("No request context");
+			});
+			const store = createSsrCookieStore();
+
+			// Act
+			store.set(CSRF_COOKIE, "token-1");
+
+			// Assert
+			expect(setCookie).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/web/src/lib/ssr-cookie-store.ts
+++ b/apps/web/src/lib/ssr-cookie-store.ts
@@ -1,0 +1,132 @@
+import {
+	getCookies,
+	getRequestProtocol,
+	getResponse,
+	setCookie,
+} from "@tanstack/react-start/server";
+import type { CookieAttributes, CookieStore } from "authula";
+
+import { COOKIE_CONSTANTS } from "@repo/data-commons";
+
+import { envServer } from "@/constants/env-server";
+
+/**
+ * Cookies we relay from an Authula response back to the browser during SSR.
+ *
+ * Only the CSRF token is relayed. The session cookie is deliberately excluded:
+ * SSR talks to the API over the internal origin, so a relayed session cookie
+ * would be scoped to the web app's host and end up as a second, differently
+ * scoped copy alongside the one the browser already holds from the API host.
+ * The API reads whichever it sees first, so the duplicate is worse than the
+ * dropped refresh.
+ */
+const RELAYED_COOKIE_NAMES: ReadonlySet<string> = new Set([
+	COOKIE_CONSTANTS.csrf.name,
+]);
+
+const NOOP_STORE: CookieStore = {
+	getAll: () => [],
+	set: () => {},
+};
+
+/**
+ * Bridges the Authula SDK's cookie store to the current SSR request/response.
+ *
+ * Reading was already wired up; writing was a no-op, which is why a hard load
+ * of an auth page never left the browser with a CSRF cookie. The API mints
+ * `authula_csrf_token` on any GET that arrives without one — including the
+ * 401 session check — and the SDK hands us every `Set-Cookie` it parses, so
+ * relaying them here is what puts the token in front of the browser.
+ */
+export const createSsrCookieStore = (): CookieStore => {
+	try {
+		// Probe the request context up front so a missing one degrades to a no-op
+		// store rather than throwing on first use.
+		getCookies();
+
+		return {
+			getAll: getRequestAndStagedCookies,
+			set: relayCookieToResponse,
+		};
+	} catch {
+		// Not inside a request context (e.g. prerender).
+		return NOOP_STORE;
+	}
+};
+
+/**
+ * The cookies to forward upstream: those the browser sent, plus anything we
+ * have already staged on the response during this request.
+ *
+ * One SSR render makes several Authula calls (the root route's session check,
+ * then the auth route's). Without the staged half, each of them would reach the
+ * API with no CSRF cookie, the API would mint a fresh token for every one, and
+ * the response would carry a pile of competing `Set-Cookie` headers. Staged
+ * values win, since they are newer than the request.
+ */
+const getRequestAndStagedCookies = (): Array<{
+	name: string;
+	value: string;
+}> => {
+	try {
+		const cookies = new Map(Object.entries(getCookies()));
+
+		for (const [name, value] of getStagedResponseCookies()) {
+			cookies.set(name, value);
+		}
+
+		return Array.from(cookies, ([name, value]) => ({ name, value }));
+	} catch {
+		return [];
+	}
+};
+
+const getStagedResponseCookies = (): Array<[string, string]> => {
+	try {
+		return getResponse()
+			.headers.getSetCookie()
+			.flatMap((setCookieHeader) => {
+				const [pair] = setCookieHeader.split(";");
+				const separatorIndex = pair?.indexOf("=") ?? -1;
+				if (!pair || separatorIndex < 1) return [];
+
+				const name = pair.slice(0, separatorIndex).trim();
+				const value = pair.slice(separatorIndex + 1).trim();
+				return RELAYED_COOKIE_NAMES.has(name)
+					? [[name, value] as [string, string]]
+					: [];
+			});
+	} catch {
+		// Response not available in this context.
+		return [];
+	}
+};
+
+const relayCookieToResponse = (
+	name: string,
+	value: string,
+	options?: CookieAttributes,
+): void => {
+	if (!RELAYED_COOKIE_NAMES.has(name)) return;
+
+	try {
+		setCookie(name, value, {
+			path: options?.path,
+			expires: options?.expires,
+			maxAge: options?.maxAge,
+			sameSite: options?.sameSite,
+			httpOnly: options?.httpOnly ?? false,
+			// Authula derives `secure` from `Request.URL.Scheme`, which is always
+			// empty on a Go server, so the upstream value is always false. Derive it
+			// from the request the browser actually made instead.
+			secure: getRequestProtocol() === "https",
+			// The upstream domain describes the internal API origin and would be
+			// meaningless to the browser. Web and API are separate hostnames in
+			// production, so the cookie needs the shared parent domain to be both
+			// readable by the browser and sent back to the API.
+			domain: envServer.authCookieDomain,
+		});
+	} catch {
+		// Response headers already sent, or no request context.
+	}
+};

--- a/docker-compose.prod.env.example
+++ b/docker-compose.prod.env.example
@@ -73,6 +73,12 @@ LOG_LEVEL=info
 AUTHULA_URL=http://api:8080/api/v1/auth
 API_URL=http://api:8080
 
+# Only needed when the web app and the API are served from different hostnames
+# (e.g. app.example.com and api.example.com). Scopes the CSRF cookie to their
+# shared parent domain so the browser can both read it and send it to the API.
+# Leave unset when both are reachable on the same host.
+AUTH_COOKIE_DOMAIN=
+
 # You can find the ID after you install the extension in Chrome
 VITE_EXTENSION_ID=
 VITE_AUTHULA_URL=http://localhost:8080/api/v1/auth

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -15,6 +15,9 @@
 		"es-toolkit": "^1.50.0",
 		"zod": "^4.4.3"
 	},
+	"dependencies": {
+		"@repo/data-commons": "workspace:*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.7",
 		"@faker-js/faker": "^10.5.0",

--- a/packages/api-client/src/mutators/custom-fetch.test.ts
+++ b/packages/api-client/src/mutators/custom-fetch.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { COOKIE_CONSTANTS } from "@repo/data-commons";
+
+import { customFetch, getCachedCsrfToken } from "./custom-fetch";
+
+const CSRF_COOKIE = COOKIE_CONSTANTS.csrf.name;
+
+const jsonResponse = (setCookie: string[]): Response =>
+	({
+		ok: true,
+		status: 200,
+		headers: {
+			getSetCookie: () => setCookie,
+		},
+		text: async () => JSON.stringify({ ok: true }),
+	}) as unknown as Response;
+
+describe("customFetch", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	describe("csrf token cache", () => {
+		test("should not cache the token on the server", async () => {
+			// Arrange — the vitest environment is node, so `window` is undefined
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () =>
+					jsonResponse([`${CSRF_COOKIE}=server-token; Path=/`]),
+				),
+			);
+
+			// Act
+			await customFetch("https://api.test/api/v1/health");
+
+			// Assert — a module-level cache would leak this token across requests
+			expect(getCachedCsrfToken()).toBeUndefined();
+		});
+
+		test("should cache the token in the browser", async () => {
+			// Arrange
+			vi.stubGlobal("window", {} as Window);
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () =>
+					jsonResponse([`${CSRF_COOKIE}=browser-token; Path=/`]),
+				),
+			);
+
+			// Act
+			await customFetch("https://api.test/api/v1/health");
+
+			// Assert
+			expect(getCachedCsrfToken()).toBe("browser-token");
+		});
+	});
+});

--- a/packages/api-client/src/mutators/custom-fetch.ts
+++ b/packages/api-client/src/mutators/custom-fetch.ts
@@ -1,5 +1,7 @@
 import { toCamelCaseKeys, toSnakeCaseKeys } from "es-toolkit";
 
+import { COOKIE_CONSTANTS } from "@repo/data-commons";
+
 /**
  * Custom HTTP client used by Orval-generated fetch functions.
  * Returns the resolved data for every response or throws an error.
@@ -11,15 +13,22 @@ import { toCamelCaseKeys, toSnakeCaseKeys } from "es-toolkit";
  *   to match the generated TypeScript types.
  */
 
-const CSRF_COOKIE_NAME = "authula_csrf_token";
+const CSRF_COOKIE_NAME = COOKIE_CONSTANTS.csrf.name;
+
+// Browser-only. On the server this module is a process singleton shared by
+// every concurrent SSR request, so caching a token here would let one user's
+// token be attached to another user's request. Server-side callers always pass
+// an explicit cookie header instead.
+const isBrowser = (): boolean => typeof window !== "undefined";
 
 let cachedCsrfToken: string | undefined;
 
 function extractCsrfFromSetCookieHeaders(headers: Headers): void {
+	if (!isBrowser()) return;
+
 	try {
-		const setCookie = typeof headers.getSetCookie === "function"
-			? headers.getSetCookie()
-			: [];
+		const setCookie =
+			typeof headers.getSetCookie === "function" ? headers.getSetCookie() : [];
 		for (const cookie of setCookie) {
 			const match = cookie.match(
 				new RegExp(`(?:^|;\\s*)${CSRF_COOKIE_NAME}=([^;]+)`),
@@ -35,7 +44,7 @@ function extractCsrfFromSetCookieHeaders(headers: Headers): void {
 }
 
 export function getCachedCsrfToken(): string | undefined {
-	return cachedCsrfToken;
+	return isBrowser() ? cachedCsrfToken : undefined;
 }
 
 // A dedicated error class makes it easy to type check and handle in UI layers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
 
   packages/api-client:
     dependencies:
+      '@repo/data-commons':
+        specifier: workspace:*
+        version: link:../data-commons
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.4(react@19.2.8)


### PR DESCRIPTION
Signing in from a freshly loaded auth page failed with 403 "missing csrf cookie" because the SSR Authula client discarded every Set-Cookie it received. The API mints authula_csrf_token on any GET arriving without one, including the 401 session check that runs during SSR, but authula-client-server.ts handed the SDK a cookie store whose writer was a no-op, so the browser's first request was the sign-in POST with no cookie to send. This wires that writer up to TanStack Start's setCookie via a new ssr-cookie-store module, which also folds already-staged cookies back into what later calls in the same render forward upstream (so one render no longer mints a token per Authula call), derives Secure from the browser-facing request protocol rather than the always-empty upstream value, and stamps an optional AUTH_COOKIE_DOMAIN for deployments where the web app and API sit on separate hostnames. Also gates the api-client CSRF token cache to the browser, since on the SSR server that module-level cache is a process singleton shared across concurrent requests. Fixes sign in, sign up, password reset and sign out on a cold load.